### PR TITLE
Adding RailsSameSiteCookie::Middleware after Rack::Runtime

### DIFF
--- a/lib/rails_same_site_cookie/railtie.rb
+++ b/lib/rails_same_site_cookie/railtie.rb
@@ -3,7 +3,7 @@ require 'rails_same_site_cookie/middleware'
 module RailsSameSiteCookie
   class Railtie < Rails::Railtie
     initializer "rails_same_site_cookie.setup_middleware" do
-      Rails.application.middleware.insert_after ActionDispatch::Static, Middleware
+      Rails.application.middleware.insert_after ::Rack::Runtime, ::RailsSameSiteCookie::Middleware
     end
   end
 end


### PR DESCRIPTION
Hi! We have been trying to use your gem, and we have a small issue with it. I hope you approve the PR. 😸 

`ActionDispatch::Static` is not enabled by default on production, neither it should be: https://stackoverflow.com/questions/34287038/why-actiondispatchstatic-is-removed-from-the-middleware-stack-in-production. This means that any Rails app with this gem will break in production. Therefore, it would be better to add this middleware after another one. In this PR, we add it after `::Rack::Runtime`, which is the one that preceeds `ActionDispatch::Static`, therefore keeping the order.

Thanks!