### PR TITLE
Bump rails to 4.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     rails_same_site_cookie (0.1.3)
-      rails (>= 4.1)
+      rails (>= 4.2)
       user_agent_parser (~> 2.5)
 
 GEM

--- a/lib/rails_same_site_cookie/version.rb
+++ b/lib/rails_same_site_cookie/version.rb
@@ -1,3 +1,3 @@
 module RailsSameSiteCookie
-  VERSION = "0.1.4"
+  VERSION = "0.1.5"
 end

--- a/rails_same_site_cookie.gemspec
+++ b/rails_same_site_cookie.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 
-  spec.add_dependency "rails", ">= 4.1"
+  spec.add_dependency "rails", ">= 4.2"
   spec.add_dependency "user_agent_parser", "~> 2.5"
 end


### PR DESCRIPTION
In a repo maintained by my team I have issues with a gem resolution conflict, caused by rails_same_site_cookie resolving a rails dependency to 4.1.2.rc1, which depends on activerecord 4.1.2.rc1.

However, I also need to use activerecord >= 4.2 in a different dependency.

One way of resolving this gem conflict would be to bump the rails dependency in rails_same_site_cookie, which is this change request.