### PR TITLE
Change rails dependency to railties

### DIFF
--- a/rails_same_site_cookie.gemspec
+++ b/rails_same_site_cookie.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 
-  spec.add_dependency "rails", ">= 4.1"
+  spec.add_dependency "railties", ">= 4.1"
   spec.add_dependency "user_agent_parser", "~> 2.5"
 end


### PR DESCRIPTION
This library only depends on `Rails::Railtie` and `Rails::Application`, both of which are defined in the `railties` gem. By depending on all of Rails, this library forces applications to pull in things like ActionCable, ActiveJob, etc. even if not used.

This library also depends on Rack, but this is a transient dependency of Railties (`railties` -> `actionpack` -> `rack`).