### PR TITLE
Add `user_filter` to config to allow having lazy checks

### DIFF
--- a/lib/rails_same_site_cookie/configuration.rb
+++ b/lib/rails_same_site_cookie/configuration.rb
@@ -1,9 +1,11 @@
 module RailsSameSiteCookie
   class Configuration
     attr_accessor :user_agent_regex
+    attr_accessor :user_filter
 
     def initialize
       @user_agent_regex = nil
+      @user_filter = nil
     end
   end
 end

--- a/lib/rails_same_site_cookie/version.rb
+++ b/lib/rails_same_site_cookie/version.rb
@@ -1,3 +1,3 @@
 module RailsSameSiteCookie
-  VERSION = "0.1.5"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
`config.user_filter` is a lambda that receives env runtime and can
decide to add `sameSite` or not

Bump to "0.2.0"

The rationale for adding this change is, the fact that we want to take into account other `Rack` environment variables such as other headers to decide whether we want to add the `sameSite`. For example, we might want to do this conditional to an existing header (`IS-MOBILE-APPLICATION`)