### PR TITLE
Add instructions to disable SameSite.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This gem fixes the above problems by explicity setting SameSite=None for all coo
 
 ### Note about HTTP requests and local testing
 Note that the gem only sets the "Secure" flag (which Chrome will also require for SameSite=None cookies) on cookies sent over HTTPS. So if you're testing on your local machine and you haven't setup your localhost to use SSL you will see warnings in Chrome about the cookies lacking the Secure flag. If the gem did set this flag in these cases, you would not see the warning and instead the cookies would simply be ignored. Once Chrome 80 is released you will either have to setup SSL on your localhost or start using a different browser for development, because Chrome will begin ignoring these cookies for lacking the Secure flag.
+To use Chrome 80+ for development without SSL you can disable following flags in Chrome settings: chrome://flags/ -> `SameSite by default cookies` and `Cookies without SameSite must be secure`.
 
 ## Installation
 


### PR DESCRIPTION
This PR adds steps to disable SameSite flags in Chrome 80+ to allow local development without SSL.