### PR TITLE
Stop sending SameSite=None to chrome over insecure connections

### DIFF
--- a/lib/rails_same_site_cookie/middleware.rb
+++ b/lib/rails_same_site_cookie/middleware.rb
@@ -22,6 +22,8 @@ module RailsSameSiteCookie
 
           cookies.each do |cookie|
             next if cookie == '' or cookie.nil?
+            next if !ssl && parser.chrome? # https://www.chromestatus.com/feature/5633521622188032
+
             if ssl and not cookie =~ /;\s*secure/i
               cookie << '; Secure'
             end

--- a/lib/rails_same_site_cookie/user_agent_checker.rb
+++ b/lib/rails_same_site_cookie/user_agent_checker.rb
@@ -21,6 +21,10 @@ module RailsSameSiteCookie
       return !missing_same_site_none_support?
     end
 
+    def chrome?
+      is_chromium_based?
+    end
+
     private
     def missing_same_site_none_support?
       has_webkit_ss_bug? or drops_unrecognized_ss_cookies?


### PR DESCRIPTION
Installing this gem breaks insecure cookies on chrome. This was discovered on my local development environment which does not run over https.

Chrome was giving this error: 

A cookie associated with a resource at `http://example.com` was set with `SameSite=None` but without `Secure`. It has been blocked, as Chrome now only delivers cookies marked `SameSite=None` if they are also marked `Secure`. You can review cookies in developer tools under Application>Storage>Cookies and see more details at https://www.chromestatus.com/feature/5633521622188032.
