### PR TITLE
Add the option to generate a legacy cookie

### DIFF
--- a/lib/rails_same_site_cookie/configuration.rb
+++ b/lib/rails_same_site_cookie/configuration.rb
@@ -1,9 +1,10 @@
 module RailsSameSiteCookie
   class Configuration
-    attr_accessor :user_agent_regex
+    attr_accessor :user_agent_regex, :generate_legacy_cookie
 
     def initialize
       @user_agent_regex = nil
+      @generate_legacy_cookie = false
     end
   end
 end

--- a/lib/rails_same_site_cookie/middleware.rb
+++ b/lib/rails_same_site_cookie/middleware.rb
@@ -13,10 +13,11 @@ module RailsSameSiteCookie
       status, headers, body = @app.call(env)
 
       regex = RailsSameSiteCookie.configuration.user_agent_regex
+      generate_legacy = RailsSameSiteCookie.configuration.generate_legacy_cookie
       set_cookie = headers['Set-Cookie']
       if (regex.nil? or regex.match(env['HTTP_USER_AGENT'])) and not (set_cookie.nil? or set_cookie.strip == '')
         parser = UserAgentChecker.new(env['HTTP_USER_AGENT'])
-        if parser.send_same_site_none?
+        if parser.send_same_site_none? || generate_legacy
           cookies = set_cookie.split(COOKIE_SEPARATOR)
           ssl = Rack::Request.new(env).ssl?
 
@@ -26,10 +27,17 @@ module RailsSameSiteCookie
               cookie << '; Secure'
             end
 
-            unless cookie =~ /;\s*samesite=/i
-              cookie << '; SameSite=None'
+            if parser.send_same_site_none?
+              unless cookie =~ /;\s*samesite=/i
+                cookie << '; SameSite=None'
+              end
             end
 
+            if generate_legacy
+              cookie_name, cookie_value = cookie.split('=', 2)
+              legacy_cookie = "#{COOKIE_SEPARATOR} #{cookie_name}-legacy=#{cookie_value}"
+              cookie << legacy_cookie
+            end
           end
 
           headers['Set-Cookie'] = cookies.join(COOKIE_SEPARATOR)

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -4,4 +4,10 @@ RSpec.describe RailsSameSiteCookie::Configuration do
     config.user_agent_regex = /dsasdd/
     expect(config.user_agent_regex).to eq(/dsasdd/)
   end
+
+  it "sets legacy cookie generation" do
+    config = described_class.new
+    config.user_agent_regex = true
+    expect(config.user_agent_regex).to be_truthy
+  end
 end

--- a/spec/rails_same_site_cookie_spec.rb
+++ b/spec/rails_same_site_cookie_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe RailsSameSiteCookie do
       expect(config.is_a?(RailsSameSiteCookie::Configuration)).to be(true)
       expect(config).to respond_to(:user_agent_regex)
       expect(config).to respond_to("user_agent_regex=")
+      expect(config).to respond_to(:generate_legacy_cookie)
+      expect(config).to respond_to("generate_legacy_cookie=")
     end
   end
 end


### PR DESCRIPTION
https://web.dev/samesite-cookie-recipes/#handling-incompatible-clients

Workaround for some incompatible browsers like some versions of Safari to handle the SameSite option.

Enabled by

```ruby
# config/initializers/rails_same_site_cookies.rb

RailsSameSiteCookie.configure do |config|
  config.generate_legacy_cookie = true
end

```